### PR TITLE
Recalc tabs on render

### DIFF
--- a/src/plugin.jsx
+++ b/src/plugin.jsx
@@ -22,7 +22,6 @@ class InstanceComponent extends React.Component {
   constructor(props) {
     super(props);
     this.state = { activeTab: 0 };
-    this.setupTabs();
   }
 
   /**

--- a/src/plugin.jsx
+++ b/src/plugin.jsx
@@ -63,6 +63,7 @@ class InstanceComponent extends React.Component {
    * @returns {React.Component} The rendered component.
    */
   render() {
+    this.setupTabs();
     return (
       <div className="rtss">
         <TabNavBar


### PR DESCRIPTION
I would use componentWillReceiveProps but it's deprecated, but since there's only one prop and if it changes it'll need to be rerendered I thought it would be ok to do the tab calculations from render.